### PR TITLE
Add explosion effect on game over in 2048

### DIFF
--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -9,7 +9,7 @@ const BoardView = () => {
     const [board, setBoard] = useState(new Board());
 
     const handleKeyDown = (event) => {
-      if (board.hasWon()) {
+      if (board.hasWon() || board.hasLost()) {
         return;
       }
   
@@ -36,10 +36,12 @@ const BoardView = () => {
         );
     });
 
+    const hasLost = board.hasLost();
+
     const tiles = board.tiles
         .filter((tile) => tile.value !== 0)
         .map((tile, index) => {
-            return <Tile tile={tile} key={index}/>;
+            return <Tile tile={tile} key={index} hasLost={hasLost}/>;
     });
 
     const resetGame = () => {

--- a/src/components/Tile.js
+++ b/src/components/Tile.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Tile = ({ tile, id }) => {
+const Tile = ({ tile, hasLost }) => {
   // 1. tile
   // 2. tile#
   // 3. position_#_#
@@ -25,6 +25,10 @@ const Tile = ({ tile, id }) => {
     classArray.push(`row_from_${tile.fromRow()}_to_${tile.toRow()}`);
     classArray.push(`column_from_${tile.fromColumn()}_to_${tile.toColumn()}`);
     classArray.push("isMoving");
+  }
+
+  if (hasLost) {
+    classArray.push("explode");
   }
 
   let classes = classArray.join(" ");

--- a/src/main.scss
+++ b/src/main.scss
@@ -243,3 +243,18 @@ body {
 .overlay .message {
   color: #666;
 }
+
+.tile.explode {
+  animation: explode 0.5s ease-out forwards;
+}
+
+@keyframes explode {
+  from {
+    opacity: 1;
+    transform: scale(1) rotate(0deg);
+  }
+  to {
+    opacity: 0;
+    transform: scale(1.5) rotate(720deg);
+  }
+}


### PR DESCRIPTION
## Summary
- stop handling keyboard input after game is lost
- mark tiles for explosion when player loses
- animate tiles with rotation/fade-out explosion effect

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_b_689cd80a1a90832d84aebb87f31aff73